### PR TITLE
fix: Do not force prettier formatting in library code, make it optional downstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.6.1](https://github.com/nrccua/apollo-rest-utils/compare/1.6.0...1.6.1) (2024-05-08)
+
 ## [1.6.0](https://github.com/nrccua/apollo-rest-utils/compare/1.5.9...1.6.0) (2024-05-08)
 
 ### [1.5.9](https://github.com/nrccua/apollo-rest-utils/compare/1.6.0...1.5.9) (2024-05-08)

--- a/lib/generateRoutes/index.ts
+++ b/lib/generateRoutes/index.ts
@@ -13,7 +13,6 @@ import SwaggerParser from '@apidevtools/swagger-parser';
 import _, { first } from 'lodash';
 import { OpenAPI, OpenAPIV3 } from 'openapi-types';
 import openapiTS, { ParameterObject, ReferenceObject, ResponseObject, SchemaObject } from 'openapi-typescript';
-import prettier from 'prettier';
 
 import { RestEndpointSchema } from '../types';
 
@@ -257,8 +256,7 @@ async function main(): Promise<void> {
     console.log(`Types file written to ${typesFilename}`);
     const api = await SwaggerParser.validate(swaggerUrl);
     const generatedTSEndpoints = generateTypescript(api, swaggerTypes, endpointId);
-    const prettierTSEndpoints = prettier.format(generatedTSEndpoints, { filepath: endpointsFilename });
-    fs.writeFileSync(endpointsFilename, prettierTSEndpoints);
+    fs.writeFileSync(endpointsFilename, generatedTSEndpoints);
     console.log(`Endpoint definition file written to ${endpointsFilename}`);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@encoura/apollo-rest-utils",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@encoura/apollo-rest-utils",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -80,5 +80,5 @@
     "update:version:major": "standard-version --release-as major && npm run test:lint:md",
     "update:version:minor": "standard-version --release-as minor && npm run test:lint:md"
   },
-  "version": "1.6.0"
+  "version": "1.6.1"
 }


### PR DESCRIPTION
Prettier is a dev-dependency, so this lib shouldn't ship runnable code that imports prettier. The choice to how to format the outputs from this library should be made downstream in the consuming project.